### PR TITLE
feat!: add more carousel tokens

### DIFF
--- a/packages/less-plugin-dls/test/specs/carousel/carousel.css
+++ b/packages/less-plugin-dls/test/specs/carousel/carousel.css
@@ -1,8 +1,9 @@
 div {
   -dls-carousel-indicator-width: 12px;
   -dls-carousel-indicator-width-current: 36px;
-  -dls-carousel-indicator-height: 2px;
-  -dls-carousel-indicator-border-radius: 1px;
+  -dls-carousel-indicator-height: 3px;
+  -dls-carousel-indicator-dot-size: 6px;
+  -dls-carousel-indicator-border-radius: 1.5px;
   -dls-carousel-indicator-spacing-outer: 12px;
   -dls-carousel-indicator-spacing-inner: 4px;
   -dls-carousel-indicator-background-color: rgba(255, 255, 255, 0.3);
@@ -11,12 +12,15 @@ div {
   -dls-carousel-indicator-background-color-current: #fff;
   -dls-carousel-control-size: 32px;
   -dls-carousel-control-border-radius: 50%;
+  -dls-carousel-control-shadow: 0 4px 6px rgba(0, 0, 0, 0.06), 0 1px 10px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.01);
   -dls-carousel-control-icon-size: 16px;
-  -dls-carousel-control-spacing: 24px;
+  -dls-carousel-control-spacing-inside: 24px;
+  -dls-carousel-control-spacing-outside: 16px;
   -dls-carousel-pages-height: 20px;
   -dls-carousel-pages-font-size: 12px;
   -dls-carousel-pages-font-color: #fff;
   -dls-carousel-pages-background-color: rgba(0, 0, 0, 0.6);
   -dls-carousel-pages-padding-x: 4px;
   -dls-carousel-pages-border-radius: 2px;
+  -dls-carousel-slide-gutter: 12px;
 }

--- a/packages/less-plugin-dls/test/specs/carousel/carousel.less
+++ b/packages/less-plugin-dls/test/specs/carousel/carousel.less
@@ -2,6 +2,7 @@ div {
   -dls-carousel-indicator-width: @dls-carousel-indicator-width;
   -dls-carousel-indicator-width-current: @dls-carousel-indicator-width-current;
   -dls-carousel-indicator-height: @dls-carousel-indicator-height;
+  -dls-carousel-indicator-dot-size: @dls-carousel-indicator-dot-size;
   -dls-carousel-indicator-border-radius: @dls-carousel-indicator-border-radius;
   -dls-carousel-indicator-spacing-outer: @dls-carousel-indicator-spacing-outer;
   -dls-carousel-indicator-spacing-inner: @dls-carousel-indicator-spacing-inner;
@@ -11,12 +12,15 @@ div {
   -dls-carousel-indicator-background-color-current: @dls-carousel-indicator-background-color-current;
   -dls-carousel-control-size: @dls-carousel-control-size;
   -dls-carousel-control-border-radius: @dls-carousel-control-border-radius;
+  -dls-carousel-control-shadow: @dls-carousel-control-shadow;
   -dls-carousel-control-icon-size: @dls-carousel-control-icon-size;
-  -dls-carousel-control-spacing: @dls-carousel-control-spacing;
+  -dls-carousel-control-spacing-inside: @dls-carousel-control-spacing-inside;
+  -dls-carousel-control-spacing-outside: @dls-carousel-control-spacing-outside;
   -dls-carousel-pages-height: @dls-carousel-pages-height;
   -dls-carousel-pages-font-size: @dls-carousel-pages-font-size;
   -dls-carousel-pages-font-color: @dls-carousel-pages-font-color;
   -dls-carousel-pages-background-color: @dls-carousel-pages-background-color;
   -dls-carousel-pages-padding-x: @dls-carousel-pages-padding-x;
   -dls-carousel-pages-border-radius: @dls-carousel-pages-border-radius;
+  -dls-carousel-slide-gutter: @dls-carousel-slide-gutter;
 }

--- a/packages/less-plugin-dls/tokens/components/carousel.less
+++ b/packages/less-plugin-dls/tokens/components/carousel.less
@@ -3,7 +3,8 @@
 /* Indicators */
 @dls-carousel-indicator-width: @dls-height-unit * 3;
 @dls-carousel-indicator-width-current: @dls-height-unit * 9;
-@dls-carousel-indicator-height: @dls-height-unit * 0.5;
+@dls-carousel-indicator-height: @dls-height-unit * 0.75;
+@dls-carousel-indicator-dot-size: @dls-height-unit * 1.5;
 @dls-carousel-indicator-border-radius: (@dls-carousel-indicator-height / 2);
 @dls-carousel-indicator-spacing-outer: @dls-padding-unit * 3;
 @dls-carousel-indicator-spacing-inner: @dls-padding-unit * 1;
@@ -15,8 +16,10 @@
 /* Controls */
 @dls-carousel-control-size: @dls-height-unit * 8;
 @dls-carousel-control-border-radius: 50%;
+@dls-carousel-control-shadow: @dls-shadow-1;
 @dls-carousel-control-icon-size: @dls-height-unit * 4;
-@dls-carousel-control-spacing: @dls-padding-unit * 6;
+@dls-carousel-control-spacing-inside: @dls-padding-unit * 6;
+@dls-carousel-control-spacing-outside: @dls-padding-unit * 4;
 
 /* Pages */
 @dls-carousel-pages-height: @dls-height-unit * 5;
@@ -25,3 +28,5 @@
 @dls-carousel-pages-background-color: @dls-background-color-translucent;
 @dls-carousel-pages-padding-x: @dls-padding-unit * 1;
 @dls-carousel-pages-border-radius: @dls-border-radius-0;
+
+@dls-carousel-slide-gutter: @dls-padding-unit * 3;


### PR DESCRIPTION
```diff
+ @dls-carousel-indicator-dot-size
+ @dls-carousel-control-shadow
- @dls-carousel-control-spacing
+ @dls-carousel-control-spacing-inside
+ @dls-carousel-control-spacing-outside
+ @dls-carousel-slide-gutter
```

把 `@dls-carousel-control-spacing` 拆成了 `@dls-carousel-control-spacing-inside` 和 `@dls-carousel-control-spacing-outside`，是一个 breaking change。@xiaodemen @code4fan 