### PR TITLE
!feat: move simple radio/checkbox group related variables out of button

### DIFF
--- a/packages/less-plugin-dls/CHANGELOG.md
+++ b/packages/less-plugin-dls/CHANGELOG.md
@@ -1,5 +1,12 @@
 > ⚠️ - Breaking Changes
 
+## 1.4.0
+
+- ⚠️ Move simple radio/checkbox group related stuff out of button:
+
+  - `@dls-button-line-spacing-strong` → `@dls-radio-group-line-spacing-strong`/`@dls-checkbox-group-line-spacing-strong`
+  - `@dls-button-spacing-simple` → `@dls-radio-group-spacing-simple`/`@dls-checkbox-group-spacing-simple`
+
 ## 1.3.0
 
 - ⚠️ Move most strong checkbox tokens to button as `@dls-button-*-selected`.

--- a/packages/less-plugin-dls/package.json
+++ b/packages/less-plugin-dls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "less-plugin-dls",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Less plugin for Baidu Light DLS.",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/less-plugin-dls/test/specs/button/button.css
+++ b/packages/less-plugin-dls/test/specs/button/button.css
@@ -116,8 +116,6 @@ div {
   -dls-button-background-color-selected-focus: #e1edff;
   -dls-button-background-color-selected-active: #c0d9ff;
   -dls-button-background-color-selected-disabled: #f2f7ff;
-  -dls-button-line-spacing-strong: 8px;
   -dls-button-min-width-stable-s: calc(24px + 4em);
   -dls-button-min-width-stable-m: calc(32px + 4em);
-  -dls-button-spacing-simple: 8px;
 }

--- a/packages/less-plugin-dls/test/specs/button/button.less
+++ b/packages/less-plugin-dls/test/specs/button/button.less
@@ -116,8 +116,6 @@ div {
   -dls-button-background-color-selected-focus: @dls-button-background-color-selected-focus;
   -dls-button-background-color-selected-active: @dls-button-background-color-selected-active;
   -dls-button-background-color-selected-disabled: @dls-button-background-color-selected-disabled;
-  -dls-button-line-spacing-strong: @dls-button-line-spacing-strong;
   -dls-button-min-width-stable-s: @dls-button-min-width-stable-s;
   -dls-button-min-width-stable-m: @dls-button-min-width-stable-m;
-  -dls-button-spacing-simple: @dls-button-spacing-simple;
 }

--- a/packages/less-plugin-dls/test/specs/checkbox/checkbox.css
+++ b/packages/less-plugin-dls/test/specs/checkbox/checkbox.css
@@ -36,6 +36,8 @@ div {
   -dls-checkbox-foreground-color-disabled: #fff;
   -dls-checkbox-shadow-focus: 0 0 0 2px rgba(0, 102, 255, 0.2);
   -dls-checkbox-group-spacing: 48px;
+  -dls-checkbox-group-spacing-simple: 8px;
+  -dls-checkbox-group-line-spacing-strong: 8px;
   -dls-checkbox-icon-size-strong: 6px;
   -dls-checkbox-icon-spacing-strong: 3px;
   -dls-checkbox-icon-color-strong: #d3d9e6;

--- a/packages/less-plugin-dls/test/specs/checkbox/checkbox.less
+++ b/packages/less-plugin-dls/test/specs/checkbox/checkbox.less
@@ -36,6 +36,8 @@ div {
   -dls-checkbox-foreground-color-disabled: @dls-checkbox-foreground-color-disabled;
   -dls-checkbox-shadow-focus: @dls-checkbox-shadow-focus;
   -dls-checkbox-group-spacing: @dls-checkbox-group-spacing;
+  -dls-checkbox-group-spacing-simple: @dls-checkbox-group-spacing-simple;
+  -dls-checkbox-group-line-spacing-strong: @dls-checkbox-group-line-spacing-strong;
   -dls-checkbox-icon-size-strong: @dls-checkbox-icon-size-strong;
   -dls-checkbox-icon-spacing-strong: @dls-checkbox-icon-spacing-strong;
   -dls-checkbox-icon-color-strong: @dls-checkbox-icon-color-strong;

--- a/packages/less-plugin-dls/test/specs/radio/radio.css
+++ b/packages/less-plugin-dls/test/specs/radio/radio.css
@@ -5,9 +5,9 @@ div {
   -dls-radio-font-color-disabled: #a8b0bf;
   -dls-radio-size-s: 14px;
   -dls-radio-size-m: 16px;
-  -dls-radio-spacing: 8px;
   -dls-radio-dot-size-s: 6px;
   -dls-radio-dot-size-m: 6px;
+  -dls-radio-spacing: 8px;
   -dls-radio-border-color: #d3d9e6;
   -dls-radio-border-color-hover: #a8b0bf;
   -dls-radio-border-color-focus: #0052cc;
@@ -35,4 +35,6 @@ div {
   -dls-radio-dot-color-disabled: #fff;
   -dls-radio-shadow-focus: 0 0 0 2px rgba(0, 102, 255, 0.2);
   -dls-radio-group-spacing: 48px;
+  -dls-radio-group-spacing-simple: 8px;
+  -dls-radio-group-line-spacing-strong: 8px;
 }

--- a/packages/less-plugin-dls/test/specs/radio/radio.less
+++ b/packages/less-plugin-dls/test/specs/radio/radio.less
@@ -5,9 +5,9 @@ div {
   -dls-radio-font-color-disabled: @dls-radio-font-color-disabled;
   -dls-radio-size-s: @dls-radio-size-s;
   -dls-radio-size-m: @dls-radio-size-m;
-  -dls-radio-spacing: @dls-radio-spacing;
   -dls-radio-dot-size-s: @dls-radio-dot-size-s;
   -dls-radio-dot-size-m: @dls-radio-dot-size-m;
+  -dls-radio-spacing: @dls-radio-spacing;
   -dls-radio-border-color: @dls-radio-border-color;
   -dls-radio-border-color-hover: @dls-radio-border-color-hover;
   -dls-radio-border-color-focus: @dls-radio-border-color-focus;
@@ -35,4 +35,6 @@ div {
   -dls-radio-dot-color-disabled: @dls-radio-dot-color-disabled;
   -dls-radio-shadow-focus: @dls-radio-shadow-focus;
   -dls-radio-group-spacing: @dls-radio-group-spacing;
+  -dls-radio-group-spacing-simple: @dls-radio-group-spacing-simple;
+  -dls-radio-group-line-spacing-strong: @dls-radio-group-line-spacing-strong;
 }

--- a/packages/less-plugin-dls/tokens/components/button.less
+++ b/packages/less-plugin-dls/tokens/components/button.less
@@ -163,9 +163,5 @@
 @dls-button-background-color-selected-active: @dls-color-brand-3;
 @dls-button-background-color-selected-disabled: @dls-color-brand-1;
 
-@dls-button-line-spacing-strong: @dls-padding-unit * 2;
-
 @dls-button-min-width-stable-s: dls-sum(@dls-button-padding-s * 2, 4em);
 @dls-button-min-width-stable-m: dls-sum(@dls-button-padding-m * 2, 4em);
-
-@dls-button-spacing-simple: @dls-padding-unit * 2;

--- a/packages/less-plugin-dls/tokens/components/checkbox.less
+++ b/packages/less-plugin-dls/tokens/components/checkbox.less
@@ -55,6 +55,8 @@
 
 /* Checkbox group */
 @dls-checkbox-group-spacing: @dls-padding-unit * 12;
+@dls-checkbox-group-spacing-simple: @dls-padding-unit * 2;
+@dls-checkbox-group-line-spacing-strong: @dls-padding-unit * 2;
 
 /* Checkbox triangle mark */
 // Use corresponding border color for the triangle

--- a/packages/less-plugin-dls/tokens/components/radio.less
+++ b/packages/less-plugin-dls/tokens/components/radio.less
@@ -52,3 +52,5 @@
 
 /* Radio group */
 @dls-radio-group-spacing: @dls-padding-unit * 12;
+@dls-radio-group-spacing-simple: @dls-padding-unit * 2;
+@dls-radio-group-line-spacing-strong: @dls-padding-unit * 2;


### PR DESCRIPTION
- ⚠️ Move simple radio/checkbox group related stuff out of button:

  - `@dls-button-line-spacing-strong` → `@dls-radio-group-line-spacing-strong`/`@dls-checkbox-group-line-spacing-strong`
  - `@dls-button-spacing-simple` → `@dls-radio-group-spacing-simple`/`@dls-checkbox-group-spacing-simple`
